### PR TITLE
Add docs for publications state filter on V2

### DIFF
--- a/source/rest-v2.md
+++ b/source/rest-v2.md
@@ -164,6 +164,18 @@ The `state` field can have one of the following values:
 | offline     | Publication is not publicly visible.                   |
 | online      | Publication is publicly visible.                       |
 
+### Filtering results
+You can filter the results list with the following query params:
+
+```shell
+# This will retrieve only publicly listed publications
+curl -H "Authorization: ApiKey <api_key>" "https://api.publitas.com/v2/groups/1/publications?state=public"
+```
+
+|        Param        |                     Options                | Description |
+|---------------------|--------------------------------------------|-------------|
+| state               | public<br>unlisted<br>online<br>offline    |Return only publicly listed publications<br>Return only unlisted publications<br>Return public and unlisted publications<br>Return only offline publications |
+
 ## Get a specific publication
 
 ```shell


### PR DESCRIPTION
Adding docs after releasing state filtering for publications on API V2 (https://github.com/publitas/revolution/pull/4822)

# Screenshot
<img width="1450" alt="Screen Shot 2022-04-01 at 10 42 31 AM" src="https://user-images.githubusercontent.com/1760039/161228764-963e6993-3103-4c7b-9a92-d02cc90cb5f9.png">