### PR TITLE
Add group and parent IDs to collection details

### DIFF
--- a/source/rest-v2.html.md
+++ b/source/rest-v2.html.md
@@ -820,14 +820,12 @@ curl "https://api.publitas.com/v2/groups/1/collections" \
       "id": 1,
       "title": "Collection 1",
       "group_id": 1,
-      "parent_collection_id": null,
       "current_product_library_id": null
     },
     {
       "id": 2,
       "title": "Collection 2",
       "group_id": 1,
-      "parent_collection_id": 1,
       "current_product_library_id": 5
     }
   ]
@@ -855,7 +853,6 @@ The JSON response returns a list of collections with the following attributes:
 | id                         | Integer | Collection ID                                            |
 | title                      | String  | Collection Title                                         |
 | group_id                   | Integer | ID of the group this collection belongs to               |
-| parent_collection_id       | Integer | ID of the parent collection, or `null` if top-level      |
 | current_product_library_id | Integer | ID of the associated product library, or `null` if unset |
 
 ## Get a specific collection
@@ -874,7 +871,6 @@ curl "https://api.publitas.com/v2/groups/1/collections/42" \
     "id": 42,
     "title": "Collection 1",
     "group_id": 1,
-    "parent_collection_id": null,
     "current_product_library_id": null
   }
 }
@@ -919,7 +915,6 @@ curl -H "Authorization: ApiKey <api_key>" --data "{
     "id": 42,
     "title": "New Collection",
     "group_id": 1,
-    "parent_collection_id": null,
     "current_product_library_id": null
   }
 }
@@ -951,7 +946,6 @@ curl "https://api.publitas.com/v2/groups/1/collections/42" \
     "id": 42,
     "title": "Updated Title",
     "group_id": 1,
-    "parent_collection_id": null,
     "current_product_library_id": null
   }
 }

--- a/source/rest-v2.html.md
+++ b/source/rest-v2.html.md
@@ -818,11 +818,17 @@ curl "https://api.publitas.com/v2/groups/1/collections" \
   "collections": [
     {
       "id": 1,
-      "title": "Collection 1"
+      "title": "Collection 1",
+      "group_id": 1,
+      "parent_collection_id": null,
+      "current_product_library_id": null
     },
     {
       "id": 2,
-      "title": "Collection 2"
+      "title": "Collection 2",
+      "group_id": 1,
+      "parent_collection_id": 1,
+      "current_product_library_id": 5
     }
   ]
 }
@@ -844,10 +850,46 @@ See the [Pagination](#pagination) section for pagination parameters.
 
 The JSON response returns a list of collections with the following attributes:
 
-| Field | Type    | Description      |
-| ----- | ------- | ---------------- |
-| id    | Integer | Collection ID    |
-| title | String  | Collection Title |
+| Field                      | Type    | Description                                              |
+| -------------------------- | ------- | -------------------------------------------------------- |
+| id                         | Integer | Collection ID                                            |
+| title                      | String  | Collection Title                                         |
+| group_id                   | Integer | ID of the group this collection belongs to               |
+| parent_collection_id       | Integer | ID of the parent collection, or `null` if top-level      |
+| current_product_library_id | Integer | ID of the associated product library, or `null` if unset |
+
+## Get a specific collection
+
+```shell
+# This endpoint retrieves a specific collection.
+curl "https://api.publitas.com/v2/groups/1/collections/42" \
+  -H "Authorization: ApiKey <api_key>"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "collection": {
+    "id": 42,
+    "title": "Collection 1",
+    "group_id": 1,
+    "parent_collection_id": null,
+    "current_product_library_id": null
+  }
+}
+```
+
+### HTTP Request
+
+`GET https://api.publitas.com/v2/groups/<Group ID>/collections/<Collection ID>`
+
+### URL Parameters
+
+| Parameter     | Description                      |
+| ------------- | -------------------------------- |
+| Group ID      | The ID of a specific group       |
+| Collection ID | The ID of a specific collection  |
 
 ## Create a collection
 
@@ -864,7 +906,8 @@ The JSON response returns a list of collections with the following attributes:
 ```shell
 curl -H "Authorization: ApiKey <api_key>" --data "{
   "collection": {
-    "title": "New Collection"
+    "title": "New Collection",
+    "parent_collection_id": 1
   }
 }"
 ```
@@ -875,7 +918,10 @@ curl -H "Authorization: ApiKey <api_key>" --data "{
 {
   "collection": {
     "id": 42,
-    "title": "New Collection"
+    "title": "New Collection",
+    "group_id": 1,
+    "parent_collection_id": 1,
+    "current_product_library_id": null
   }
 }
 ```
@@ -884,9 +930,55 @@ curl -H "Authorization: ApiKey <api_key>" --data "{
 
 The following fields need to be sent within a collection scope (see the right panel for an example):
 
-| Name  | Type   | Required | Description      |
-| ----- | ------ | -------- | ---------------- |
-| title | String | Yes      | Collection Title |
+| Name                 | Type    | Required | Description                                     |
+| -------------------- | ------- | -------- | ----------------------------------------------- |
+| title                | String  | Yes      | Collection Title                                |
+| parent_collection_id | Integer | No       | ID of the parent collection to nest under       |
+
+## Update a collection
+
+```shell
+# This will update a collection's title and parent.
+curl "https://api.publitas.com/v2/groups/1/collections/42" \
+  -H "Authorization: ApiKey <api_key>" \
+  -X PUT \
+  --data "collection[title]=Updated Title&collection[parent_collection_id]=1"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "collection": {
+    "id": 42,
+    "title": "Updated Title",
+    "group_id": 1,
+    "parent_collection_id": 1,
+    "current_product_library_id": null
+  }
+}
+```
+
+### HTTP Request
+
+`PUT https://api.publitas.com/v2/groups/<Group ID>/collections/<Collection ID>`
+
+### URL Parameters
+
+| Parameter     | Description                        |
+| ------------- | ---------------------------------- |
+| Group ID      | The ID of a specific group         |
+| Collection ID | The ID of the collection to update |
+
+### Request body parameters
+
+The following fields need to be sent within a collection scope (see the right panel for an example):
+
+| Name                       | Type    | Required | Description                                                        |
+| -------------------------- | ------- | -------- | ------------------------------------------------------------------ |
+| title                      | String  | No       | Collection Title                                                   |
+| parent_collection_id       | Integer | No       | ID of the parent collection to nest under, or `null` to un-nest    |
+| current_product_library_id | Integer | No       | ID of the product library to associate, or `null` to clear         |
 
 ## Delete a collection
 

--- a/source/rest-v2.html.md
+++ b/source/rest-v2.html.md
@@ -906,8 +906,7 @@ curl "https://api.publitas.com/v2/groups/1/collections/42" \
 ```shell
 curl -H "Authorization: ApiKey <api_key>" --data "{
   "collection": {
-    "title": "New Collection",
-    "parent_collection_id": 1
+    "title": "New Collection"
   }
 }"
 ```
@@ -920,7 +919,7 @@ curl -H "Authorization: ApiKey <api_key>" --data "{
     "id": 42,
     "title": "New Collection",
     "group_id": 1,
-    "parent_collection_id": 1,
+    "parent_collection_id": null,
     "current_product_library_id": null
   }
 }
@@ -930,19 +929,18 @@ curl -H "Authorization: ApiKey <api_key>" --data "{
 
 The following fields need to be sent within a collection scope (see the right panel for an example):
 
-| Name                 | Type    | Required | Description                                     |
-| -------------------- | ------- | -------- | ----------------------------------------------- |
-| title                | String  | Yes      | Collection Title                                |
-| parent_collection_id | Integer | No       | ID of the parent collection to nest under       |
+| Name  | Type   | Required | Description      |
+| ----- | ------ | -------- | ---------------- |
+| title | String | Yes      | Collection Title |
 
 ## Update a collection
 
 ```shell
-# This will update a collection's title and parent.
+# This will update a collection's title.
 curl "https://api.publitas.com/v2/groups/1/collections/42" \
   -H "Authorization: ApiKey <api_key>" \
   -X PUT \
-  --data "collection[title]=Updated Title&collection[parent_collection_id]=1"
+  --data "collection[title]=Updated Title"
 ```
 
 > The above command returns JSON structured like this:
@@ -953,7 +951,7 @@ curl "https://api.publitas.com/v2/groups/1/collections/42" \
     "id": 42,
     "title": "Updated Title",
     "group_id": 1,
-    "parent_collection_id": 1,
+    "parent_collection_id": null,
     "current_product_library_id": null
   }
 }
@@ -974,11 +972,10 @@ curl "https://api.publitas.com/v2/groups/1/collections/42" \
 
 The following fields need to be sent within a collection scope (see the right panel for an example):
 
-| Name                       | Type    | Required | Description                                                        |
-| -------------------------- | ------- | -------- | ------------------------------------------------------------------ |
-| title                      | String  | No       | Collection Title                                                   |
-| parent_collection_id       | Integer | No       | ID of the parent collection to nest under, or `null` to un-nest    |
-| current_product_library_id | Integer | No       | ID of the product library to associate, or `null` to clear         |
+| Name                       | Type    | Required | Description                                                |
+| -------------------------- | ------- | -------- | ---------------------------------------------------------- |
+| title                      | String  | No       | Collection Title                                           |
+| current_product_library_id | Integer | No       | ID of the product library to associate, or `null` to clear |
 
 ## Delete a collection
 


### PR DESCRIPTION
Updated the JSON response structure for collections to include additional fields for `group_id`, and `current_product_library_id`. This change improves data organization and allows for better nesting of collections.

- Added `group_id` to indicate the collection's group
- Updated response and request examples to reflect new fields