### PR TITLE
Add description to slug fields

### DIFF
--- a/source/graphql.html.md
+++ b/source/graphql.html.md
@@ -1071,7 +1071,7 @@ A hotspot containing products
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
-A string that may contain letters, numbers, hyphens, and underscores. It does not follow an industry standard format.
+A string that may contain lowercase letters, numbers, hyphens, and underscores. It does not follow an industry standard format.
 
 </td>
 </tr>
@@ -1135,7 +1135,7 @@ A string that may contain letters, numbers, hyphens, and underscores. It does no
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
-A string that may contain letters, numbers, hyphens, and underscores. It does not follow an industry standard format.
+A string that may contain lowercase letters, numbers, hyphens, and underscores. It does not follow an industry standard format.
 
 </td>
 </tr>

--- a/source/graphql.html.md
+++ b/source/graphql.html.md
@@ -1069,7 +1069,11 @@ A hotspot containing products
 <tr>
 <td colspan="2" valign="top"><strong id="publication.groupslug">groupSlug</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
-<td></td>
+<td>
+
+A string that may contain letters, numbers, hyphens, and underscores. It does not follow an industry standard format.
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong id="publication.grouptitle">groupTitle</strong></td>
@@ -1129,7 +1133,11 @@ A hotspot containing products
 <tr>
 <td colspan="2" valign="top"><strong id="publication.slug">slug</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
-<td></td>
+<td>
+
+A string that may contain letters, numbers, hyphens, and underscores. It does not follow an industry standard format.
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong id="publication.spreads">spreads</strong></td>

--- a/source/graphql.html.md
+++ b/source/graphql.html.md
@@ -1108,7 +1108,11 @@ A string that may contain lowercase letters, numbers, hyphens, and underscores. 
 <tr>
 <td colspan="2" valign="top"><strong id="publication.publicationslug">publicationSlug</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
-<td></td>
+<td>
+
+A string that may contain lowercase letters, numbers, hyphens, and underscores. It does not follow an industry standard format.
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong id="publication.publicationtitle">publicationTitle</strong></td>
@@ -1223,7 +1227,11 @@ Returns the last _n_ elements from the list.
 <tr>
 <td colspan="2" valign="top"><strong id="publicationlistitem.groupslug">groupSlug</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
-<td></td>
+<td>
+
+A string that may contain lowercase letters, numbers, hyphens, and underscores. It does not follow an industry standard format.
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong id="publicationlistitem.grouptitle">groupTitle</strong></td>
@@ -1238,7 +1246,11 @@ Returns the last _n_ elements from the list.
 <tr>
 <td colspan="2" valign="top"><strong id="publicationlistitem.publicationslug">publicationSlug</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
-<td></td>
+<td>
+
+A string that may contain lowercase letters, numbers, hyphens, and underscores. It does not follow an industry standard format.
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong id="publicationlistitem.publicationtitle">publicationTitle</strong></td>

--- a/source/graphql.html.md
+++ b/source/graphql.html.md
@@ -322,12 +322,20 @@ Finds a publication by ID or by both slug and the group slug
 <tr>
 <td colspan="2" align="right" valign="top">groupSlug</td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+The group's URL slug. Consists of lowercase letters, numbers, hyphens, and underscores.
+
+</td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">slug</td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+The publication's URL slug. Consists of lowercase letters, numbers, hyphens, and underscores.
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong id="query.publicationbyurl">publicationByUrl</strong></td>
@@ -402,7 +410,7 @@ Filter to publications belonging to this group
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Filter to publications belonging to the group with this slug
+Filter to publications belonging to the group with this slug. Consists of lowercase letters, numbers, hyphens, and underscores.
 
 </td>
 </tr>
@@ -1071,7 +1079,7 @@ A hotspot containing products
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
-A string that may contain lowercase letters, numbers, hyphens, and underscores. It does not follow an industry standard format.
+The group's URL slug. Consists of lowercase letters, numbers, hyphens, and underscores.
 
 </td>
 </tr>
@@ -1110,7 +1118,7 @@ A string that may contain lowercase letters, numbers, hyphens, and underscores. 
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
-A string that may contain lowercase letters, numbers, hyphens, and underscores. It does not follow an industry standard format.
+The publication's URL slug. Consists of lowercase letters, numbers, hyphens, and underscores.
 
 </td>
 </tr>
@@ -1139,7 +1147,7 @@ A string that may contain lowercase letters, numbers, hyphens, and underscores. 
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
-A string that may contain lowercase letters, numbers, hyphens, and underscores. It does not follow an industry standard format.
+The publication's URL slug. Consists of lowercase letters, numbers, hyphens, and underscores.
 
 </td>
 </tr>
@@ -1229,7 +1237,7 @@ Returns the last _n_ elements from the list.
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
-A string that may contain lowercase letters, numbers, hyphens, and underscores. It does not follow an industry standard format.
+The group's URL slug. Consists of lowercase letters, numbers, hyphens, and underscores.
 
 </td>
 </tr>
@@ -1248,7 +1256,7 @@ A string that may contain lowercase letters, numbers, hyphens, and underscores. 
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
-A string that may contain lowercase letters, numbers, hyphens, and underscores. It does not follow an industry standard format.
+The publication's URL slug. Consists of lowercase letters, numbers, hyphens, and underscores.
 
 </td>
 </tr>


### PR DESCRIPTION
Adds a description to the Publication's `slug` and `groupSlug` fields, explaining how the returned value is formatted. Uses the description coming from https://github.com/publitas/revolution/pull/8709.

Postmortem task: https://app.asana.com/1/11178336824504/project/1200560401714912/task/1213788719059413?focus=true